### PR TITLE
Add required runtime dependency & update project url

### DIFF
--- a/srcpkgs/ignis/template
+++ b/srcpkgs/ignis/template
@@ -13,7 +13,7 @@ pkg-config
 python3
 gobject-introspection
 git"
-depends="python3 python3-gobject python3-click python3-cairo python3-loguru gobject-introspection"
+depends="python3 python3-gobject python3-click python3-cairo python3-loguru gobject-introspection gtk4-layer-shell-devel"
 short_desc="A widget framework for building desktop shells, written and configurable in Python."
 maintainer="binarylinuxx <aar58384@gmail.com>"
 license="LGPL-2.1-or-later"

--- a/srcpkgs/ignis/template
+++ b/srcpkgs/ignis/template
@@ -17,8 +17,8 @@ depends="python3 python3-gobject python3-click python3-cairo python3-loguru gobj
 short_desc="A widget framework for building desktop shells, written and configurable in Python."
 maintainer="binarylinuxx <aar58384@gmail.com>"
 license="LGPL-2.1-or-later"
-homepage="https://github.com/linkfrg/ignis"
-distfiles="https://github.com/linkfrg/ignis/releases/download/v${version}/ignis-v${version}.tar.gz"
+homepage="https://github.com/ignis-sh/ignis"
+distfiles="https://github.com/ignis-sh/ignis/releases/download/v${version}/ignis-v${version}.tar.gz"
 checksum="3ea240440584f336a31874f79a1e76e3a9f18651ff2ecaac7dab54807c1fd371"
 configure_args="--wrap-mode=forcefallback"
 


### PR DESCRIPTION
After using your template I figured out that `gtk4-layer-shell-devel` is required at runtime to use ignis, so I made this PR. Also, the project url in template was updated to the current one.